### PR TITLE
Split up issuers

### DIFF
--- a/cluster_issuer.yaml
+++ b/cluster_issuer.yaml
@@ -1,47 +1,9 @@
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: self-signed
-  namespace: cert-manager
-spec:
-  selfSigned: {}
-
----
-
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: root-print-your-cert-ca
-  namespace: cert-manager
-spec:
-  isCA: true
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-  secretName: root-print-your-cert-ca
-  commonName: The cert-manager maintainers Root CA
-  subject:
-    organizations:
-    - CNCF
-    organizationalUnits:
-    - cert-manager
-  duration: 876000h # 100 years.
-  issuerRef:
-    name: self-signed
-    kind: Issuer
-
----
-
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: root-print-your-cert-ca-issuer
-  namespace: cert-manager
-spec:
-  ca:
-    secretName: root-print-your-cert-ca
-
----
+# This file creates an intermediate cert for issuing client certificates,
+# and assumes that a root CA issuer has already been configured in the
+# cert-manager namespace
+#
+# See root_issuer_dev.yaml  for creating a dev root
+# See root_issuer_prod.yaml for creating a production root from a known secret
 
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/root_issuer_dev.yaml
+++ b/root_issuer_dev.yaml
@@ -1,0 +1,50 @@
+# This file creates a self-signed root certificate for dev purposes.
+#
+# For "production", we'd ideally want to use the same root certificate
+# for multiple different events and so the issuer would be based off of
+# a manually created Secret which holds the root.
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: self-signed
+  namespace: cert-manager
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: root-print-your-cert-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: root-print-your-cert-ca
+  commonName: The cert-manager maintainers Root CA
+  subject:
+    organizations:
+    - CNCF
+    organizationalUnits:
+    - cert-manager
+  duration: 876000h # 100 years.
+  issuerRef:
+    name: self-signed
+    kind: Issuer
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: root-print-your-cert-ca-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: root-print-your-cert-ca
+
+

--- a/root_issuer_prod.yaml
+++ b/root_issuer_prod.yaml
@@ -1,0 +1,16 @@
+# This file creates an issuer from a root certificate, assuming that
+# the root was provided in a secret manually.
+#
+# The secret should be called root-print-your-cert-ca and should be in the
+# cert-manager namespace
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: root-print-your-cert-ca-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: root-print-your-cert-ca
+
+


### PR DESCRIPTION
This'll make it easier to generate a root which we can "keep" in between demo sessions