### PR TITLE
Update dates and wording on landing page; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This experiment was run at the cert-manager booth at KubeCon EU 2022 in
 Valencia, KubeCon NA 2022 in Detroit, KubeCon EU 2023 in Amsterdam,
-and KubeCon NA 2023 in Chicago.
+KubeCon NA 2023 in Chicago, and Kubecon EU 2024 in Paris.
 
 ⚠️ Except for the URL <cert-manager.github.io/print-your-cert/> which should
 work forever, the other URLs and IPs presented in this README are temporary.

--- a/landing.html
+++ b/landing.html
@@ -73,11 +73,9 @@
                  margin: 20px auto;
                  "
           >
-          The email will not be displayed on the screen, just your name. The name
-          and email are used to fill in the "Subject" field of the X.509
-          certificate, and won't be used for anything else than printing the
-          certificate. The data submitted stays on the Pi, and will be removed
-          after 10 November 2022 (the printed QR code will still work).
+          Your email will not be displayed on-screen, just your name. These
+          details are only used to fill in the "Subject" field of the X.509
+          certificate, and will be removed within six months.
       </p>
 
       <div class="push"></div>


### PR DESCRIPTION
We're at Kubecon EU 2024, and noticed that the user data disclaimer in landing.html was outdated. I've reworded it on with @maelvls' advice on what actually happens under the hood.

Also added Kubecon Paris to the README :)