### PR TITLE
Rename Venafi -> CyberArk -> Palo Alto Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ kubectl apply -f root_issuer_prod.yaml
 kubectl apply -f cluster_issuer.yaml
 ```
 
-Then, decrypt the root CA. The passphrase is available in the Venafi 1Password
+Then, decrypt the root CA. The passphrase is available in the Palo Alto Networks 1Password
 in the `cert-manager-team` vault.
 
 ```bash

--- a/certificate.html
+++ b/certificate.html
@@ -143,7 +143,7 @@
           </p>
           <p class="small">
           Project proudly supported by
-          <a href="https://venafi.com" target="_blank">Venafi</a>
+          <a href="https://www.paloaltonetworks.com" target="_blank">Palo Alto Networks</a>
           </p>
           <p class="small">
           Design by <a href="https://constantinchirila.com" target="_blank">Constantin Chirila</a>

--- a/error.html
+++ b/error.html
@@ -36,7 +36,7 @@
       </p>
       <p class="small">
       Project proudly supported by
-      <a href="https://venafi.com" target="_blank">Venafi</a>
+      <a href="https://www.paloaltonetworks.com" target="_blank">Palo Alto Networks</a>
       </p>
       <p class="small">
       Design by <a href="https://constantinchirila.com" target="_blank">Constantin Chirila</a>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       </p>
       <p class="small">
         Project proudly supported by
-        <a href="https://venafi.com" target="_blank">Venafi</a>
+        <a href="https://www.paloaltonetworks.com" target="_blank">Palo Alto Networks</a>
       </p>
       <p class="small">
         Design by

--- a/landing.html
+++ b/landing.html
@@ -130,7 +130,7 @@
       </p>
       <p class="small">
       Project proudly supported by
-      <a href="https://venafi.com" target="_blank">Venafi, a CyberArk Company</a>
+      <a href="https://www.paloaltonetworks.com" target="_blank">Palo Alto Networks, a CyberArk Company</a>
       </p>
       <p class="small">
       Design by <a href="https://constantinchirila.com" target="_blank">Constantin Chirila</a>

--- a/list.html
+++ b/list.html
@@ -59,7 +59,7 @@
       </p>
       <p class="small">
       Project proudly supported by
-      <a href="https://venafi.com" target="_blank">Venafi</a>
+      <a href="https://www.paloaltonetworks.com" target="_blank">Palo Alto Networks</a>
       </p>
       <p class="small">
       Design by <a href="https://constantinchirila.com" target="_blank">Constantin Chirila</a>


### PR DESCRIPTION
Due to acquisitions